### PR TITLE
Do not support --net option.

### DIFF
--- a/opencompose-specification.asc
+++ b/opencompose-specification.asc
@@ -227,9 +227,15 @@ labels:
 
 
 #### net
-*TODO*
-----
-----
+*Not supported*
+
+It does not make sense for any network specification to be a part of application specification.
+Network specification should be part of the operation and infrastructure specification,
+abstracted from the developers. The developers should only be concerned with the services
+they depend on when designing their application spec, and the orchestration tool should
+take care of deciding the best network configuration for the application when it's
+run. In this way, we can have separation of concerns, and the same application spec
+can run untweaked across multiple infrastructures.
 
 
 #### ports


### PR DESCRIPTION
Drop support for `--net` option in opencompose as it's more of an infrastructure/operation specification than an application specification. All the developers should be bothered with is to identify the services they depend on, and the orchestration engine should take care running the application in the proper scope (namespace, network, etc.) so that the application can access the services it depends on.
