### PR TITLE
Just have one command directive to run commands. Removing entrypoint etc. Less confusion.

### DIFF
--- a/opencompose-specification.asc
+++ b/opencompose-specification.asc
@@ -33,8 +33,11 @@ services:
   <service name>:
     type: <String>
     container_name: <String>
-    command: <String>
-    entrypoint: <String>
+    command:
+      - <Executable>
+      - <Optional Args>
+      - <Optional Args>
+      - ...
     image: <String>
     environment:
       <Key:Value>
@@ -88,10 +91,8 @@ image: nginx
 
 
 #### command
-Command to override the default command in the container. Optionally a list of arguments can be provided.
+Command to override the default command baked into the container. OpenCompose expects complete command (executable and the optional args) to be specified in a list format.
 ----
-  command: python setup.py
-
   command:
     - python
     - setup.py
@@ -211,16 +212,6 @@ services:
     type: "internal"
 ----
 
-
-#### entrypoint
-Overrides the container's default entrypoint. Can be passed as a single entry or a list form.
-----
-entrypoint: /scripts/run.sh
-
-entrypoint:
-  - /bin/bash
-  - -c
-----
 
 # Open Issues
 


### PR DESCRIPTION
Cleaning up the mess of commands, args and entrypoint. For now let's have just one way to do things. 